### PR TITLE
Upgrade `json-smart` to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <jenkins.version>2.401.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>
+    <json-smart.version>2.5.0</json-smart.version>
   </properties>
 
   <dependencyManagement>
@@ -42,6 +43,21 @@
         <version>2641.v88e707466454</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>net.minidev</groupId>
+        <artifactId>accessors-smart</artifactId>
+        <version>${json-smart.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.minidev</groupId>
+        <artifactId>json-smart</artifactId>
+        <version>${json-smart.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.minidev</groupId>
+        <artifactId>json-smart-action</artifactId>
+        <version>${json-smart.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
We were bundling a slightly out-of-date version of this transitive dependency. By managing everything that is a part of https://github.com/netplex/json-smart-v2 (even if we aren't consuming it today) we ensure that we are future-proof to future changes. By defining the version as a property we ensure that Dependabot can update it. Unfortunately `json-smart` doesn't appear to ship a BOM, so we have to add every single artifact.

### Testing done

`mvn clean verify`; observed the newer version was bundled.