### PR TITLE
Fix scope of dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,21 +45,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>net.minidev</groupId>
-        <artifactId>accessors-smart</artifactId>
-        <version>${json-smart.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>net.minidev</groupId>
-        <artifactId>json-smart</artifactId>
-        <version>${json-smart.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>net.minidev</groupId>
-        <artifactId>json-smart-action</artifactId>
-        <version>${json-smart.version}</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -99,6 +84,21 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>asm-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>net.minidev</groupId>
+      <artifactId>accessors-smart</artifactId>
+      <version>${json-smart.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.minidev</groupId>
+      <artifactId>json-smart</artifactId>
+      <version>${json-smart.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.minidev</groupId>
+      <artifactId>json-smart-action</artifactId>
+      <version>${json-smart.version}</version>
     </dependency>
   </dependencies>
   <repositories>


### PR DESCRIPTION
While attempting to link `oic-auth-plugin` against this plugin with

```xml
diff --git a/pom.xml b/pom.xml
index 399325c..400161c 100644
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,11 @@
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>commons-text-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>json-path-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
@@ -175,6 +179,11 @@
           <groupId>commons-text</groupId>
           <artifactId>commons-text</artifactId>
         </exclusion>
+        <exclusion>
+          <!-- consume from json-path-api plugin -->
+          <groupId>net.minidev</groupId>
+          <artifactId>json-smart</artifactId>
+        </exclusion>
         <exclusion>
           <!-- consume from Jenkins core -->
           <groupId>org.slf4j</groupId>
```

I got compilation errors because the Json-smart dependencies were in runtime scope rather than compile scope. With this PR the problem is solved and I can use this library plugin from consumers that need to link against Json-smart at compile time.